### PR TITLE
WIP: POC - Discover all tiles in parallel

### DIFF
--- a/tokendito/aws.py
+++ b/tokendito/aws.py
@@ -89,7 +89,7 @@ def authenticate_to_roles(config, urls):
             sys.exit(1)
         responses.append((url, saml_response_string, saml_xml, label))
 
-    return responses
+    return responses[0] if tile_count == 1 else responses
 
 
 def assume_role(role_arn, provider_arn, saml):

--- a/tokendito/http_client.py
+++ b/tokendito/http_client.py
@@ -46,6 +46,8 @@ class HTTPClient:
         """Initialize the HTTPClient with a session object."""
         user_agent = generate_user_agent()
         self.session = requests.Session()
+        adapter = requests.adapters.HTTPAdapter(pool_maxsize=256)
+        self.session.mount("https://", adapter)
         self.session.headers.update({"User-Agent": user_agent})
 
     def add_cookies(self, cookies):


### PR DESCRIPTION
### Description

The changes in this pull request include modifications to three files in the codebase:

### Changes:
- Updated the `authenticate_to_roles` function in `tokendito/aws.py` to return only the first item in the `responses` list if `tile_count` is equal to 1.
- In the `__init__` method of the `HTTPClient` class in `tokendito/http_client.py`, added code to set the `pool_maxsize` for the HTTP adapter.
- Imported the `concurrent.futures` module in `tokendito/user.py`.
- Modified the `cmd_interface` function in `tokendito/user.py` to use multithreading with ThreadPoolExecutor to concurrently authenticate to AWS roles.

### PR Summary:
- Updates the `authenticate_to_roles` function to return only the first response when there is only one tile.
- Sets the `pool_maxsize` parameter for the HTTP adapter in the `HTTPClient` class.
- Adds multithreading using ThreadPoolExecutor for the authentication process in the `cmd_interface` function.
  
These changes aim to optimize the authentication process by utilizing multithreading for improved performance.